### PR TITLE
Remove `object` fields from card and card parts

### DIFF
--- a/src/scooze/card.py
+++ b/src/scooze/card.py
@@ -154,7 +154,6 @@ class FullCard(OracleCard):
         tcgplayer_id: int | None
         tcgplayer_etched_id: int | None
         cardmarket_id: int | None
-        object: str
         oracle_id: str | None
         prints_search_uri: str
         rulings_uri: str
@@ -244,7 +243,6 @@ class FullCard(OracleCard):
         tcgplayer_id: int | None = None,
         tcgplayer_etched_id: int | None = None,
         cardmarket_id: int | None = None,
-        _object: str = "card",
         oracle_id: str | None = None,
         prints_search_uri: str = "",
         rulings_uri: str = "",
@@ -329,7 +327,6 @@ class FullCard(OracleCard):
         self.tcgplayer_id = tcgplayer_id
         self.tcgplayer_etched_id = tcgplayer_etched_id
         self.cardmarket_id = cardmarket_id
-        self.object = _object
         self.oracle_id = oracle_id
         self.prints_search_uri = prints_search_uri
         self.rulings_uri = rulings_uri

--- a/src/scooze/cardparts.py
+++ b/src/scooze/cardparts.py
@@ -101,7 +101,6 @@ class FullCardFace(CardFace):
         loyalty: int | None
         mana_cost: str | None
         name: str | None
-        object: str | None
         oracle_id: str | None
         oracle_text: str | None
         power: str | None
@@ -126,7 +125,6 @@ class FullCardFace(CardFace):
         loyalty: int | None = None,
         mana_cost: str | None = None,
         name: str | None = None,
-        _object: str | None = None,
         oracle_id: str | None = None,
         oracle_text: str | None = None,
         power: str | None = None,
@@ -148,7 +146,6 @@ class FullCardFace(CardFace):
         self.loyalty = loyalty
         self.mana_cost = mana_cost
         self.name = name
-        self.object = _object
         self.oracle_id = oracle_id
         self.oracle_text = oracle_text
         self.power = power
@@ -216,7 +213,6 @@ class RelatedCard:
 
     Attributes:
         scryfall_id: str | None
-        object: str | None
         component: str | None
         name: str | None
         type_line: str | None
@@ -226,14 +222,12 @@ class RelatedCard:
     def __init__(
         self,
         scryfall_id: str | None = None,
-        _object: str | None = None,
         component: str | None = None,
         name: str | None = None,
         type_line: str | None = None,
         uri: str | None = None,
     ):
         self.scryfall_id = scryfall_id
-        self.object = _object
         self.component = component  # TODO(#36): convert to enum?
         self.name = name
         self.type_line = type_line

--- a/src/scooze/models/card.py
+++ b/src/scooze/models/card.py
@@ -89,7 +89,6 @@ class FullCardModel(CardModel, validate_assignment=True):
         tcgplayer_id: int | None
         tcgplayer_etched_id: int | None
         cardmarket_id: int | None
-        object: str
         oracle_id: str
         prints_search_uri: str
         rulings_uri: str
@@ -199,10 +198,6 @@ class FullCardModel(CardModel, validate_assignment=True):
     )
     cardmarket_id: int | None = Field(
         description="This card's ID on Cardmarket, or `idProduct` in their system.",
-    )
-    object: str = Field(
-        default="card",
-        description="Always `card` for Card objects.",
     )
     oracle_id: str | None = Field(
         default="",

--- a/src/scooze/models/cardparts.py
+++ b/src/scooze/models/cardparts.py
@@ -57,7 +57,6 @@ class CardFaceModel(BaseModel, validate_assignment=True):
         loyalty: int | None
         mana_cost: str
         name: str
-        object: str
         oracle_id: str | None
         oracle_text: str | None
         power: str | None
@@ -101,9 +100,6 @@ class CardFaceModel(BaseModel, validate_assignment=True):
     )
     name: str = Field(
         description="Name of this face.",
-    )
-    object: str = Field(
-        description="Always `card_face`, for a card face object.",
     )
     oracle_id: str | None = Field(
         description="Oracle ID of this face, for reversible cards.",
@@ -192,7 +188,6 @@ class RelatedCardModel(BaseModel, validate_assignment=True):
 
     Attributes:
         id: str
-        object: str
         component: str
         name: str
         type_line: str
@@ -202,9 +197,6 @@ class RelatedCardModel(BaseModel, validate_assignment=True):
     id: str = Field(
         description="ID of linked component.",
     )  # NOTE: Scryfall ID
-    object: str = Field(
-        description="Always `related_card` for this object.",
-    )
     component: str = Field(
         description="One of `token`, `meld_part`, `meld_result`, or `combo_piece`.",
     )  # TODO(#36): convert to enum?


### PR DESCRIPTION
Scryfall uses `object` as a marker for which type of object is currently being looked at in their JSON data; we're not using that marker to construct these objects at any point, and that meta-tag isn't useful downstream when we already know the instance of a class, so we shouldn't need to support this field.