### PR TITLE
[BUGFIX] Resolve typo in `illustration_id`

### DIFF
--- a/src/scooze/models/card.py
+++ b/src/scooze/models/card.py
@@ -172,7 +172,7 @@ class FullCardModel(CardModel, validate_assignment=True):
         games: Which games this print is available on, from among
           paper, mtgo, and arena.
         highres_image: Whether this card has a high-res image available.
-        illustation_id: A UUID for the particlar artwork on this print,
+        illustration_id: A UUID for the particlar artwork on this print,
           consistent across art reprints.
         image_status: The quality/status of images available for this card.
           Either missing, placeholder, lowres, or highres_scan.
@@ -409,7 +409,7 @@ class FullCardModel(CardModel, validate_assignment=True):
         default=False,
         description="Whether this card has a high-res image available.",
     )
-    illustation_id: str | None = Field(
+    illustration_id: str | None = Field(
         default="",
         description="A UUID for the particlar artwork on this print, consistent across art reprints.",
     )

--- a/src/scooze/models/cardparts.py
+++ b/src/scooze/models/cardparts.py
@@ -105,7 +105,7 @@ class CardFaceModel(BaseModel, validate_assignment=True):
         default=None,
         description="Flavor text of this face, if any.",
     )
-    illustration_id: int | None = Field(
+    illustration_id: str | None = Field(
         default=None,
         description="Scryfall illustration ID of this face, if any.",
     )


### PR DESCRIPTION
On CardModel - should be `illustration_id`, not `illustation_id`
On CardFaceModel - should be `str` not `int`