### PR TITLE
Delete the API README

### DIFF
--- a/src/scooze/api/README.md
+++ b/src/scooze/api/README.md
@@ -1,1 +1,0 @@
-Python wrappers for synchronous database I/O.


### PR DESCRIPTION
We messed up during deploy, so I'm tacking this on after the fact. It'll get cleaned up in the next release.