### PR TITLE
Fix "Event Loop Closed"

### DIFF
--- a/src/scooze/api/__init__.py
+++ b/src/scooze/api/__init__.py
@@ -66,7 +66,9 @@ class ScoozeApi(AbstractContextManager):
             The first matching card, or None if none were found.
         """
 
-        return card_api.get_card_by(property_name=property_name, value=value, card_class=self.card_class)
+        return card_api.get_card_by(
+            runner=self.runner, property_name=property_name, value=value, card_class=self.card_class
+        )
 
     @_check_for_safe_context
     def get_cards_by(

--- a/src/scooze/api/__init__.py
+++ b/src/scooze/api/__init__.py
@@ -66,9 +66,8 @@ class ScoozeApi(AbstractContextManager):
             The first matching card, or None if none were found.
         """
 
-        return card_api.get_card_by(
-            runner=self.runner, property_name=property_name, value=value, card_class=self.card_class
-        )
+        return self.runner.run(card_api.get_card_by(property_name=property_name, value=value, card_class=self.card_class
+        ))
 
     @_check_for_safe_context
     def get_cards_by(
@@ -95,15 +94,14 @@ class ScoozeApi(AbstractContextManager):
             were found.
         """
 
-        return card_api.get_cards_by(
-            runner=self.runner,
+        return self.runner.run(card_api.get_cards_by(
             property_name=property_name,
             values=values,
             card_class=self.card_class,
             paginated=paginated,
             page=page,
             page_size=page_size,
-        )
+        ))
 
     # region Convenience methods for single-card lookup
 
@@ -120,12 +118,11 @@ class ScoozeApi(AbstractContextManager):
             A card with the given name if found, or None if none were found.
         """
 
-        return card_api.get_card_by(
-            runner=self.runner,
+        return self.runner.run(card_api.get_card_by(
             property_name="name",
             value=name,
             card_class=self.card_class,
-        )
+        ))
 
     @cache
     @_check_for_safe_context
@@ -140,12 +137,11 @@ class ScoozeApi(AbstractContextManager):
             A card with the given Oracle ID if found, or None if none were found.
         """
 
-        return card_api.get_card_by(
-            runner=self.runner,
+        return self.runner(card_api.get_card_by(
             property_name="oracle_id",
             value=oracle_id,
             card_class=self.card_class,
-        )
+        ))
 
     @cache
     @_check_for_safe_context
@@ -160,12 +156,11 @@ class ScoozeApi(AbstractContextManager):
             A card with the given Scryfall ID if found, or None if none were found.
         """
 
-        return card_api.get_card_by(
-            runner=self.runner,
+        return self.runner.run(card_api.get_card_by(
             property_name="scryfall_id",
             value=scryfall_id,
             card_class=self.card_class,
-        )
+        ))
 
     # endregion
 
@@ -185,12 +180,11 @@ class ScoozeApi(AbstractContextManager):
            A list of cards from the given set, or empty list if none were found.
         """
 
-        return card_api.get_cards_by(
-            runner=self.runner,
+        return self.runner.run(card_api.get_cards_by(
             property_name="set",
             values=[set_code],
             card_class=self.card_class,
-        )
+        ))
 
     # TODO(#146): add function get_cards_by_format (format, legality)
 
@@ -208,7 +202,7 @@ class ScoozeApi(AbstractContextManager):
             The ID of the inserted card, or None if it was unable.
         """
 
-        return card_api.add_card(runner=self.runner, card=card)
+        return self.runner.run(card_api.add_card(card=card))
 
     @_check_for_safe_context
     def add_cards(self, cards: List[CardT]) -> List[ObjectId]:
@@ -222,7 +216,7 @@ class ScoozeApi(AbstractContextManager):
             The IDs of the inserted cards, or empty list if unable.
         """
 
-        return card_api.add_cards(runner=self.runner, cards=cards)
+        return self.runner.run(card_api.add_cards(cards=cards))
 
     @_check_for_safe_context
     def delete_card(self, id: str) -> bool:
@@ -236,7 +230,7 @@ class ScoozeApi(AbstractContextManager):
             True if the card is deleted, False otherwise.
         """
 
-        return card_api.delete_card(runner=self.runner, id=id)
+        return self.runner.run(card_api.delete_card(id=id))
 
     @_check_for_safe_context
     def delete_cards_all(self) -> int:
@@ -247,7 +241,7 @@ class ScoozeApi(AbstractContextManager):
             The number of cards deleted, or None if none could be deleted.
         """
 
-        return card_api.delete_cards_all(runner=self.runner)
+        return self.runner.run(card_api.delete_cards_all())
 
     # endregion
 
@@ -271,10 +265,9 @@ class ScoozeApi(AbstractContextManager):
             bulk_file_dir: The path to the folder containing the ScryfallBulkFile.
         """
 
-        return bulkdata_api.load_card_file(
-            runner=self.runner,
+        return self.runner.run(bulkdata_api.load_card_file(
             file_type=file_type,
             bulk_file_dir=bulk_file_dir,
-        )
+        ))
 
     # endregion

--- a/src/scooze/api/__init__.py
+++ b/src/scooze/api/__init__.py
@@ -66,8 +66,9 @@ class ScoozeApi(AbstractContextManager):
             The first matching card, or None if none were found.
         """
 
-        return self.runner.run(card_api.get_card_by(property_name=property_name, value=value, card_class=self.card_class
-        ))
+        return self.runner.run(
+            card_api.get_card_by(property_name=property_name, value=value, card_class=self.card_class)
+        )
 
     @_check_for_safe_context
     def get_cards_by(
@@ -94,14 +95,16 @@ class ScoozeApi(AbstractContextManager):
             were found.
         """
 
-        return self.runner.run(card_api.get_cards_by(
-            property_name=property_name,
-            values=values,
-            card_class=self.card_class,
-            paginated=paginated,
-            page=page,
-            page_size=page_size,
-        ))
+        return self.runner.run(
+            card_api.get_cards_by(
+                property_name=property_name,
+                values=values,
+                card_class=self.card_class,
+                paginated=paginated,
+                page=page,
+                page_size=page_size,
+            )
+        )
 
     # region Convenience methods for single-card lookup
 
@@ -118,11 +121,13 @@ class ScoozeApi(AbstractContextManager):
             A card with the given name if found, or None if none were found.
         """
 
-        return self.runner.run(card_api.get_card_by(
-            property_name="name",
-            value=name,
-            card_class=self.card_class,
-        ))
+        return self.runner.run(
+            card_api.get_card_by(
+                property_name="name",
+                value=name,
+                card_class=self.card_class,
+            )
+        )
 
     @cache
     @_check_for_safe_context
@@ -137,11 +142,13 @@ class ScoozeApi(AbstractContextManager):
             A card with the given Oracle ID if found, or None if none were found.
         """
 
-        return self.runner(card_api.get_card_by(
-            property_name="oracle_id",
-            value=oracle_id,
-            card_class=self.card_class,
-        ))
+        return self.runner(
+            card_api.get_card_by(
+                property_name="oracle_id",
+                value=oracle_id,
+                card_class=self.card_class,
+            )
+        )
 
     @cache
     @_check_for_safe_context
@@ -156,11 +163,13 @@ class ScoozeApi(AbstractContextManager):
             A card with the given Scryfall ID if found, or None if none were found.
         """
 
-        return self.runner.run(card_api.get_card_by(
-            property_name="scryfall_id",
-            value=scryfall_id,
-            card_class=self.card_class,
-        ))
+        return self.runner.run(
+            card_api.get_card_by(
+                property_name="scryfall_id",
+                value=scryfall_id,
+                card_class=self.card_class,
+            )
+        )
 
     # endregion
 
@@ -180,11 +189,13 @@ class ScoozeApi(AbstractContextManager):
            A list of cards from the given set, or empty list if none were found.
         """
 
-        return self.runner.run(card_api.get_cards_by(
-            property_name="set",
-            values=[set_code],
-            card_class=self.card_class,
-        ))
+        return self.runner.run(
+            card_api.get_cards_by(
+                property_name="set",
+                values=[set_code],
+                card_class=self.card_class,
+            )
+        )
 
     # TODO(#146): add function get_cards_by_format (format, legality)
 
@@ -265,9 +276,11 @@ class ScoozeApi(AbstractContextManager):
             bulk_file_dir: The path to the folder containing the ScryfallBulkFile.
         """
 
-        return self.runner.run(bulkdata_api.load_card_file(
-            file_type=file_type,
-            bulk_file_dir=bulk_file_dir,
-        ))
+        return self.runner.run(
+            bulkdata_api.load_card_file(
+                file_type=file_type,
+                bulk_file_dir=bulk_file_dir,
+            )
+        )
 
     # endregion

--- a/src/scooze/api/__init__.py
+++ b/src/scooze/api/__init__.py
@@ -41,13 +41,14 @@ class ScoozeApi(AbstractContextManager):
         self.safe_context = False
 
     def __enter__(self):
-        asyncio.run(mongo.mongo_connect())
         self.safe_context = True
+        self.runner = asyncio.Runner()
+        self.runner.run(mongo.mongo_connect())
 
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        asyncio.run(mongo.mongo_close())
+        self.runner.run(mongo.mongo_close())
 
     # region Card endpoints
 
@@ -93,6 +94,7 @@ class ScoozeApi(AbstractContextManager):
         """
 
         return card_api.get_cards_by(
+            runner=self.runner,
             property_name=property_name,
             values=values,
             card_class=self.card_class,
@@ -117,6 +119,7 @@ class ScoozeApi(AbstractContextManager):
         """
 
         return card_api.get_card_by(
+            runner=self.runner,
             property_name="name",
             value=name,
             card_class=self.card_class,
@@ -136,6 +139,7 @@ class ScoozeApi(AbstractContextManager):
         """
 
         return card_api.get_card_by(
+            runner=self.runner,
             property_name="oracle_id",
             value=oracle_id,
             card_class=self.card_class,
@@ -155,6 +159,7 @@ class ScoozeApi(AbstractContextManager):
         """
 
         return card_api.get_card_by(
+            runner=self.runner,
             property_name="scryfall_id",
             value=scryfall_id,
             card_class=self.card_class,
@@ -179,6 +184,7 @@ class ScoozeApi(AbstractContextManager):
         """
 
         return card_api.get_cards_by(
+            runner=self.runner,
             property_name="set",
             values=[set_code],
             card_class=self.card_class,
@@ -200,7 +206,7 @@ class ScoozeApi(AbstractContextManager):
             The ID of the inserted card, or None if it was unable.
         """
 
-        return card_api.add_card(card=card)
+        return card_api.add_card(runner=self.runner, card=card)
 
     @_check_for_safe_context
     def add_cards(self, cards: List[CardT]) -> List[ObjectId]:
@@ -214,7 +220,7 @@ class ScoozeApi(AbstractContextManager):
             The IDs of the inserted cards, or empty list if unable.
         """
 
-        return card_api.add_cards(cards=cards)
+        return card_api.add_cards(runner=self.runner, cards=cards)
 
     @_check_for_safe_context
     def delete_card(self, id: str) -> bool:
@@ -228,7 +234,7 @@ class ScoozeApi(AbstractContextManager):
             True if the card is deleted, False otherwise.
         """
 
-        return card_api.delete_card(id=id)
+        return card_api.delete_card(runner=self.runner, id=id)
 
     @_check_for_safe_context
     def delete_cards_all(self) -> int:
@@ -239,7 +245,7 @@ class ScoozeApi(AbstractContextManager):
             The number of cards deleted, or None if none could be deleted.
         """
 
-        return card_api.delete_cards_all()
+        return card_api.delete_cards_all(runner=self.runner)
 
     # endregion
 
@@ -264,6 +270,7 @@ class ScoozeApi(AbstractContextManager):
         """
 
         return bulkdata_api.load_card_file(
+            runner=self.runner,
             file_type=file_type,
             bulk_file_dir=bulk_file_dir,
         )

--- a/src/scooze/api/bulkdata.py
+++ b/src/scooze/api/bulkdata.py
@@ -8,7 +8,7 @@ from scooze.catalogs import ScryfallBulkFile
 from scooze.models.card import CardModelIn
 
 
-def load_card_file(file_type: ScryfallBulkFile, bulk_file_dir: str) -> None:
+def load_card_file(runner: asyncio.Runner, file_type: ScryfallBulkFile, bulk_file_dir: str) -> None:
     """
     Loads the desired file from the given directory into a local Mongo
     database. Attempts to download it from Scryfall if it isn't found.
@@ -29,24 +29,23 @@ def load_card_file(file_type: ScryfallBulkFile, bulk_file_dir: str) -> None:
             results_count = 0
             current_batch = []
             card_jsons = ijson.items(cards_file, "item")
-            with asyncio.Runner() as runner:
 
-                def load_batch(batch) -> int:
-                    batch_results = runner.run(db.add_cards(batch))
-                    if batch_results is not None:
-                        return len(batch_results)
-                    return 0
+            def load_batch(batch) -> int:
+                batch_results = runner.run(db.add_cards(batch))
+                if batch_results is not None:
+                    return len(batch_results)
+                return 0
 
-                for card_json in card_jsons:
-                    if (validated_card := _try_validate_card(card_json)) is not None:
-                        current_batch.append(validated_card)
-                        current_batch_count += 1
-                        if current_batch_count >= batch_size:
-                            results_count += load_batch(current_batch)
-                            current_batch = []
-                            current_batch_count = 0
-                            print(f"Finished processing {results_count} cards...", end="\r")
-                results_count += load_batch(current_batch)
+            for card_json in card_jsons:
+                if (validated_card := _try_validate_card(card_json)) is not None:
+                    current_batch.append(validated_card)
+                    current_batch_count += 1
+                    if current_batch_count >= batch_size:
+                        results_count += load_batch(current_batch)
+                        current_batch = []
+                        current_batch_count = 0
+                        print(f"Finished processing {results_count} cards...", end="\r")
+            results_count += load_batch(current_batch)
 
             print(f"Loaded {results_count} cards to the database.")
 

--- a/src/scooze/api/bulkdata.py
+++ b/src/scooze/api/bulkdata.py
@@ -8,7 +8,7 @@ from scooze.catalogs import ScryfallBulkFile
 from scooze.models.card import CardModelIn
 
 
-def load_card_file(runner: asyncio.Runner, file_type: ScryfallBulkFile, bulk_file_dir: str) -> None:
+async def load_card_file(file_type: ScryfallBulkFile, bulk_file_dir: str) -> None:
     """
     Loads the desired file from the given directory into a local Mongo
     database. Attempts to download it from Scryfall if it isn't found.
@@ -30,8 +30,8 @@ def load_card_file(runner: asyncio.Runner, file_type: ScryfallBulkFile, bulk_fil
             current_batch = []
             card_jsons = ijson.items(cards_file, "item")
 
-            def load_batch(batch) -> int:
-                batch_results = runner.run(db.add_cards(batch))
+            async def load_batch(batch) -> int:
+                batch_results = await db.add_cards(batch)
                 if batch_results is not None:
                     return len(batch_results)
                 return 0
@@ -41,11 +41,11 @@ def load_card_file(runner: asyncio.Runner, file_type: ScryfallBulkFile, bulk_fil
                     current_batch.append(validated_card)
                     current_batch_count += 1
                     if current_batch_count >= batch_size:
-                        results_count += load_batch(current_batch)
+                        results_count += await load_batch(current_batch)
                         current_batch = []
                         current_batch_count = 0
                         print(f"Finished processing {results_count} cards...", end="\r")
-            results_count += load_batch(current_batch)
+            results_count += await load_batch(current_batch)
 
             print(f"Loaded {results_count} cards to the database.")
 

--- a/src/scooze/api/card.py
+++ b/src/scooze/api/card.py
@@ -7,7 +7,7 @@ from scooze.card import CardT, FullCard
 from scooze.models.card import CardModelIn, CardModelOut
 
 
-def get_card_by(property_name: str, value, card_class: CardT = FullCard) -> CardT:
+def get_card_by(runner: asyncio.Runner, property_name: str, value, card_class: CardT = FullCard) -> CardT:
     """
     Search the database for the first card that matches the given criteria.
 
@@ -20,7 +20,7 @@ def get_card_by(property_name: str, value, card_class: CardT = FullCard) -> Card
         The first matching card, or None if none were found.
     """
 
-    card_model = asyncio.run(
+    card_model = runner.run(
         db.get_card_by_property(
             property_name=property_name,
             value=value,
@@ -31,6 +31,7 @@ def get_card_by(property_name: str, value, card_class: CardT = FullCard) -> Card
 
 
 def get_cards_by(
+    runner: asyncio.Runner,
     property_name: str,
     values: list[Any],
     card_class: CardT = FullCard,
@@ -54,7 +55,7 @@ def get_cards_by(
         were found.
     """
 
-    card_models = asyncio.run(
+    card_models = runner.run(
         db.get_cards_by_property(
             property_name=property_name,
             values=values,
@@ -66,7 +67,7 @@ def get_cards_by(
     return [card_class.from_model(m) for m in card_models]
 
 
-def add_card(card: CardT) -> ObjectId:
+def add_card(runner: asyncio.Runner, card: CardT) -> ObjectId:
     """
     Add a card to the database.
 
@@ -78,12 +79,12 @@ def add_card(card: CardT) -> ObjectId:
     """
 
     card_model = CardModelIn.model_validate(card.__dict__)
-    model = asyncio.run(db.add_card(card=card_model))
+    model = runner.run(db.add_card(card=card_model))
     if model is not None:
         return model.id
 
 
-def add_cards(cards: List[CardT]) -> List[ObjectId]:
+def add_cards(runner: asyncio.Runner, cards: List[CardT]) -> List[ObjectId]:
     """
     Add a list of cards to the database.
 
@@ -95,10 +96,10 @@ def add_cards(cards: List[CardT]) -> List[ObjectId]:
     """
 
     card_models = [CardModelIn.model_validate(card.__dict__) for card in cards]
-    return asyncio.run(db.add_cards(cards=card_models))
+    return runner.run(db.add_cards(cards=card_models))
 
 
-def delete_card(id: str) -> bool:
+def delete_card(runner: asyncio.Runner, id: str) -> bool:
     """
     Delete a card from the database.
 
@@ -109,10 +110,10 @@ def delete_card(id: str) -> bool:
         True if the card is deleted, False otherwise.
     """
 
-    return asyncio.run(db.delete_card(id=id)) is not None
+    return runner.run(db.delete_card(id=id)) is not None
 
 
-def delete_cards_all() -> int:
+def delete_cards_all(runner: asyncio.Runner) -> int:
     """
     Delete all cards in the database.
 
@@ -120,4 +121,4 @@ def delete_cards_all() -> int:
         The number of cards deleted, or None if none could be deleted.
     """
 
-    return asyncio.run(db.delete_cards_all())
+    return runner.run(db.delete_cards_all())

--- a/src/scooze/api/card.py
+++ b/src/scooze/api/card.py
@@ -7,7 +7,7 @@ from scooze.card import CardT, FullCard
 from scooze.models.card import CardModelIn, CardModelOut
 
 
-def get_card_by(runner: asyncio.Runner, property_name: str, value, card_class: CardT = FullCard) -> CardT:
+async def get_card_by(property_name: str, value, card_class: CardT = FullCard) -> CardT:
     """
     Search the database for the first card that matches the given criteria.
 
@@ -20,18 +20,15 @@ def get_card_by(runner: asyncio.Runner, property_name: str, value, card_class: C
         The first matching card, or None if none were found.
     """
 
-    card_model = runner.run(
-        db.get_card_by_property(
-            property_name=property_name,
-            value=value,
-        )
+    card_model = await db.get_card_by_property(
+        property_name=property_name,
+        value=value,
     )
     if card_model is not None:
         return card_class.from_model(card_model)
 
 
-def get_cards_by(
-    runner: asyncio.Runner,
+async def get_cards_by(
     property_name: str,
     values: list[Any],
     card_class: CardT = FullCard,
@@ -55,19 +52,17 @@ def get_cards_by(
         were found.
     """
 
-    card_models = runner.run(
-        db.get_cards_by_property(
-            property_name=property_name,
-            values=values,
-            paginated=paginated,
-            page=page,
-            page_size=page_size,
-        )
+    card_models = await db.get_cards_by_property(
+        property_name=property_name,
+        values=values,
+        paginated=paginated,
+        page=page,
+        page_size=page_size,
     )
     return [card_class.from_model(m) for m in card_models]
 
 
-def add_card(runner: asyncio.Runner, card: CardT) -> ObjectId:
+async def add_card(card: CardT) -> ObjectId:
     """
     Add a card to the database.
 
@@ -79,12 +74,12 @@ def add_card(runner: asyncio.Runner, card: CardT) -> ObjectId:
     """
 
     card_model = CardModelIn.model_validate(card.__dict__)
-    model = runner.run(db.add_card(card=card_model))
+    model = await db.add_card(card=card_model)
     if model is not None:
         return model.id
 
 
-def add_cards(runner: asyncio.Runner, cards: List[CardT]) -> List[ObjectId]:
+async def add_cards(cards: List[CardT]) -> List[ObjectId]:
     """
     Add a list of cards to the database.
 
@@ -96,10 +91,10 @@ def add_cards(runner: asyncio.Runner, cards: List[CardT]) -> List[ObjectId]:
     """
 
     card_models = [CardModelIn.model_validate(card.__dict__) for card in cards]
-    return runner.run(db.add_cards(cards=card_models))
+    return await db.add_cards(cards=card_models)
 
 
-def delete_card(runner: asyncio.Runner, id: str) -> bool:
+async def delete_card(id: str) -> bool:
     """
     Delete a card from the database.
 
@@ -110,10 +105,10 @@ def delete_card(runner: asyncio.Runner, id: str) -> bool:
         True if the card is deleted, False otherwise.
     """
 
-    return runner.run(db.delete_card(id=id)) is not None
+    return await db.delete_card(id=id) is not None
 
 
-def delete_cards_all(runner: asyncio.Runner) -> int:
+async def delete_cards_all() -> int:
     """
     Delete all cards in the database.
 
@@ -121,4 +116,4 @@ def delete_cards_all(runner: asyncio.Runner) -> int:
         The number of cards deleted, or None if none could be deleted.
     """
 
-    return runner.run(db.delete_cards_all())
+    return await db.delete_cards_all()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,5 +1,14 @@
+import asyncio
+
 import pytest
 from scooze.card import Card, FullCard, OracleCard
+
+
+@pytest.fixture(scope="session")
+def asyncio_runner():
+    with asyncio.Runner() as runner:
+        yield runner
+
 
 # region Card fixtures
 

--- a/tests/api/test_bulkdata.py
+++ b/tests/api/test_bulkdata.py
@@ -18,19 +18,19 @@ def bulk_file_dir() -> str:
 
 
 @patch("scooze.database.card.add_cards")
-def test_load_card_file(mock_add: MagicMock, cards_full: list[FullCard], file_type, bulk_file_dir, capfd):
+def test_load_card_file(mock_add: MagicMock, cards_full, file_type, bulk_file_dir, asyncio_runner, capfd):
     ids = [ObjectId() for _ in cards_full]
     mock_add.return_value: list[ObjectId] = ids
-    bulk_api.load_card_file(file_type=file_type, bulk_file_dir=bulk_file_dir)
+    bulk_api.load_card_file(runner=asyncio_runner, file_type=file_type, bulk_file_dir=bulk_file_dir)
     captured = capfd.readouterr()
     expected = f"Loading {file_type} file into the database...\nLoaded {len(ids)} cards to the database.\n"
     assert captured.out == expected
 
 
 @patch("scooze.database.card.add_cards")
-def test_load_card_file_bad(mock_add: MagicMock, file_type, bulk_file_dir, capfd):
+def test_load_card_file_bad(mock_add: MagicMock, file_type, bulk_file_dir, asyncio_runner, capfd):
     mock_add.return_value = None
-    bulk_api.load_card_file(file_type=file_type, bulk_file_dir=bulk_file_dir)
+    bulk_api.load_card_file(runner=asyncio_runner, file_type=file_type, bulk_file_dir=bulk_file_dir)
     captured = capfd.readouterr()
     expected = f"Loading {file_type} file into the database...\nNo cards loaded into database.\n"
     assert captured.out == expected

--- a/tests/api/test_bulkdata.py
+++ b/tests/api/test_bulkdata.py
@@ -21,7 +21,7 @@ def bulk_file_dir() -> str:
 def test_load_card_file(mock_add: MagicMock, cards_full, file_type, bulk_file_dir, asyncio_runner, capfd):
     ids = [ObjectId() for _ in cards_full]
     mock_add.return_value: list[ObjectId] = ids
-    bulk_api.load_card_file(runner=asyncio_runner, file_type=file_type, bulk_file_dir=bulk_file_dir)
+    asyncio_runner.run(bulk_api.load_card_file(file_type=file_type, bulk_file_dir=bulk_file_dir))
     captured = capfd.readouterr()
     expected = f"Loading {file_type} file into the database...\nLoaded {len(ids)} cards to the database.\n"
     assert captured.out == expected
@@ -30,7 +30,7 @@ def test_load_card_file(mock_add: MagicMock, cards_full, file_type, bulk_file_di
 @patch("scooze.database.card.add_cards")
 def test_load_card_file_bad(mock_add: MagicMock, file_type, bulk_file_dir, asyncio_runner, capfd):
     mock_add.return_value = None
-    bulk_api.load_card_file(runner=asyncio_runner, file_type=file_type, bulk_file_dir=bulk_file_dir)
+    asyncio_runner.run(bulk_api.load_card_file(file_type=file_type, bulk_file_dir=bulk_file_dir))
     captured = capfd.readouterr()
     expected = f"Loading {file_type} file into the database...\nNo cards loaded into database.\n"
     assert captured.out == expected

--- a/tests/api/test_card_api.py
+++ b/tests/api/test_card_api.py
@@ -11,7 +11,7 @@ def test_get_base_card(mock_get: MagicMock, recall_base, asyncio_runner):
     model = CardModelOut.model_validate(recall_base.__dict__)
     model.id = ObjectId()
     mock_get.return_value: CardModelOut = model
-    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=model.id, card_class=Card)
+    result = asyncio_runner.run(card_api.get_card_by(property_name="id", value=model.id, card_class=Card))
     assert result == recall_base
 
 
@@ -20,7 +20,7 @@ def test_get_oracle_card(mock_get: MagicMock, recall_oracle, asyncio_runner):
     model = CardModelOut.model_validate(recall_oracle.__dict__)
     model.id = ObjectId()
     mock_get.return_value: CardModelOut = model
-    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=model.id, card_class=OracleCard)
+    result = asyncio_runner.run(card_api.get_card_by(property_name="id", value=model.id, card_class=OracleCard))
     assert result == recall_oracle
 
 
@@ -29,14 +29,14 @@ def test_get_full_card(mock_get: MagicMock, recall_full, asyncio_runner):
     model = CardModelOut.model_validate(recall_full.__dict__)
     model.id = ObjectId()
     mock_get.return_value: CardModelOut = model
-    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=model.id, card_class=FullCard)
+    result = asyncio_runner.run(card_api.get_card_by(property_name="id", value=model.id, card_class=FullCard))
     assert result == recall_full
 
 
 @patch("scooze.database.card.get_card_by_property")
 def test_get_card_bad(mock_get: MagicMock, asyncio_runner):
     mock_get.return_value = None
-    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=ObjectId(), card_class=Card)
+    result = asyncio_runner.run(card_api.get_card_by(property_name="id", value=ObjectId(), card_class=Card))
     assert result is None
 
 
@@ -45,7 +45,7 @@ def test_get_base_cards(mock_get: MagicMock, cards_base, asyncio_runner):
     models = [CardModelOut.model_validate(card.__dict__) for card in cards_base]
     ids = [model.id for model in models]
     mock_get.return_value: list[CardModelOut] = models
-    results = card_api.get_cards_by(runner=asyncio_runner, property_name="id", values=ids, card_class=Card)
+    results = asyncio_runner.run(card_api.get_cards_by(property_name="id", values=ids, card_class=Card))
     assert results == cards_base
 
 
@@ -54,7 +54,7 @@ def test_get_oracle_cards(mock_get: MagicMock, cards_oracle, asyncio_runner):
     models = [CardModelOut.model_validate(card.__dict__) for card in cards_oracle]
     ids = [model.id for model in models]
     mock_get.return_value: list[CardModelOut] = models
-    results = card_api.get_cards_by(runner=asyncio_runner, property_name="id", values=ids, card_class=OracleCard)
+    results = asyncio_runner.run(card_api.get_cards_by(property_name="id", values=ids, card_class=OracleCard))
     assert results == cards_oracle
 
 
@@ -63,16 +63,15 @@ def test_get_full_cards(mock_get: MagicMock, cards_full, asyncio_runner):
     models = [CardModelOut.model_validate(card.__dict__) for card in cards_full]
     ids = [model.id for model in models]
     mock_get.return_value: list[CardModelOut] = models
-    results = card_api.get_cards_by(runner=asyncio_runner, property_name="id", values=ids, card_class=FullCard)
+    results = asyncio_runner.run(card_api.get_cards_by(property_name="id", values=ids, card_class=FullCard))
     assert results == cards_full
 
 
 @patch("scooze.database.card.get_cards_by_property")
 def test_get_cards_bad(mock_get: MagicMock, cards_base, asyncio_runner):
     mock_get.return_value = []
-    results = card_api.get_cards_by(
-        runner=asyncio_runner, property_name="id", values=[ObjectId() for _ in cards_base], card_class=Card
-    )
+    results = asyncio_runner.run(card_api.get_cards_by(property_name="id", values=[ObjectId() for _ in cards_base], card_class=Card
+    ))
     assert results == []
 
 
@@ -81,7 +80,7 @@ def test_add_base_card(mock_add: MagicMock, recall_base, asyncio_runner):
     model = CardModelOut.model_validate(recall_base.__dict__)
     model.id = ObjectId()
     mock_add.return_value: CardModelOut = model
-    result = card_api.add_card(runner=asyncio_runner, card=recall_base)
+    result = asyncio_runner.run(card_api.add_card(card=recall_base))
     assert result == model.id
 
 
@@ -90,7 +89,7 @@ def test_add_oracle_card(mock_add: MagicMock, recall_full, asyncio_runner):
     model = CardModelOut.model_validate(recall_full.__dict__)
     model.id = ObjectId()
     mock_add.return_value: CardModelOut = model
-    result = card_api.add_card(runner=asyncio_runner, card=recall_full)
+    result = asyncio_runner.run(card_api.add_card(card=recall_full))
     assert result == model.id
 
 
@@ -99,14 +98,14 @@ def test_add_full_card(mock_add: MagicMock, recall_full, asyncio_runner):
     model = CardModelOut.model_validate(recall_full.__dict__)
     model.id = ObjectId()
     mock_add.return_value: CardModelOut = model
-    result = card_api.add_card(runner=asyncio_runner, card=recall_full)
+    result = asyncio_runner.run(card_api.add_card(card=recall_full))
     assert result == model.id
 
 
 @patch("scooze.database.card.add_card")
 def test_add_card_bad(mock_add: MagicMock, recall_base, asyncio_runner):
     mock_add.return_value = None
-    result = card_api.add_card(runner=asyncio_runner, card=recall_base)
+    result = asyncio_runner.run(card_api.add_card(card=recall_base))
     assert result is None
 
 
@@ -114,7 +113,7 @@ def test_add_card_bad(mock_add: MagicMock, recall_base, asyncio_runner):
 def test_add_base_cards(mock_add: MagicMock, cards_base, asyncio_runner):
     ids = [ObjectId() for _ in cards_base]
     mock_add.return_value: list[ObjectId] = ids
-    results = card_api.add_cards(runner=asyncio_runner, cards=cards_base)
+    results = asyncio_runner.run(card_api.add_cards(cards=cards_base))
     assert results == ids
 
 
@@ -122,7 +121,7 @@ def test_add_base_cards(mock_add: MagicMock, cards_base, asyncio_runner):
 def test_add_oracle_cards(mock_add: MagicMock, cards_oracle, asyncio_runner):
     ids = [ObjectId() for _ in cards_oracle]
     mock_add.return_value: list[ObjectId] = ids
-    results = card_api.add_cards(runner=asyncio_runner, cards=cards_oracle)
+    results = asyncio_runner.run(card_api.add_cards(cards=cards_oracle))
     assert results == ids
 
 
@@ -130,26 +129,26 @@ def test_add_oracle_cards(mock_add: MagicMock, cards_oracle, asyncio_runner):
 def test_add_full_cards(mock_add: MagicMock, cards_full, asyncio_runner):
     ids = [ObjectId() for _ in cards_full]
     mock_add.return_value: list[ObjectId] = ids
-    results = card_api.add_cards(runner=asyncio_runner, cards=cards_full)
+    results = asyncio_runner.run(card_api.add_cards(cards=cards_full))
     assert results == ids
 
 
 @patch("scooze.database.card.add_cards")
 def test_add_cards_bad(mock_add: MagicMock, cards_base, asyncio_runner):
     mock_add.return_value = []
-    results = card_api.add_cards(runner=asyncio_runner, cards=cards_base)
+    results = asyncio_runner.run(card_api.add_cards(cards=cards_base))
     assert results == []
 
 
 @patch("scooze.database.card.delete_cards_all")
 def test_delete_cards(mock_delete: MagicMock, asyncio_runner):
     mock_delete.return_value: int = 4
-    results = card_api.delete_cards_all(runner=asyncio_runner)
+    results = asyncio_runner.run(card_api.delete_cards_all())
     assert results == 4
 
 
 @patch("scooze.database.card.delete_cards_all")
 def test_delete_cards_bad(mock_delete: MagicMock, asyncio_runner):
     mock_delete.return_value = None
-    results = card_api.delete_cards_all(runner=asyncio_runner)
+    results = asyncio_runner.run(card_api.delete_cards_all())
     assert results is None

--- a/tests/api/test_card_api.py
+++ b/tests/api/test_card_api.py
@@ -86,11 +86,11 @@ def test_add_base_card(mock_add: MagicMock, recall_base, asyncio_runner):
 
 
 @patch("scooze.database.card.add_card")
-def test_add_oracle_card(mock_add: MagicMock, recall_full, asyncio_runner):
-    model = CardModelOut.model_validate(recall_full.__dict__)
+def test_add_oracle_card(mock_add: MagicMock, recall_oracle, asyncio_runner):
+    model = CardModelOut.model_validate(recall_oracle.__dict__)
     model.id = ObjectId()
     mock_add.return_value: CardModelOut = model
-    result = asyncio_runner.run(card_api.add_card(card=recall_full))
+    result = asyncio_runner.run(card_api.add_card(card=recall_oracle))
     assert result == model.id
 
 

--- a/tests/api/test_card_api.py
+++ b/tests/api/test_card_api.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
 import scooze.api.card as card_api
 from bson import ObjectId
 from scooze.card import Card, FullCard, OracleCard
@@ -8,147 +7,149 @@ from scooze.models.card import CardModelOut
 
 
 @patch("scooze.database.card.get_card_by_property")
-def test_get_base_card(mock_get: MagicMock, recall_base: Card):
+def test_get_base_card(mock_get: MagicMock, recall_base, asyncio_runner):
     model = CardModelOut.model_validate(recall_base.__dict__)
     model.id = ObjectId()
     mock_get.return_value: CardModelOut = model
-    result = card_api.get_card_by("id", model.id, card_class=Card)
+    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=model.id, card_class=Card)
     assert result == recall_base
 
 
 @patch("scooze.database.card.get_card_by_property")
-def test_get_oracle_card(mock_get: MagicMock, recall_oracle: OracleCard):
+def test_get_oracle_card(mock_get: MagicMock, recall_oracle, asyncio_runner):
     model = CardModelOut.model_validate(recall_oracle.__dict__)
     model.id = ObjectId()
     mock_get.return_value: CardModelOut = model
-    result = card_api.get_card_by("id", model.id, card_class=OracleCard)
+    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=model.id, card_class=OracleCard)
     assert result == recall_oracle
 
 
 @patch("scooze.database.card.get_card_by_property")
-def test_get_full_card(mock_get: MagicMock, recall_full: FullCard):
+def test_get_full_card(mock_get: MagicMock, recall_full, asyncio_runner):
     model = CardModelOut.model_validate(recall_full.__dict__)
     model.id = ObjectId()
     mock_get.return_value: CardModelOut = model
-    result = card_api.get_card_by("id", model.id, card_class=FullCard)
+    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=model.id, card_class=FullCard)
     assert result == recall_full
 
 
 @patch("scooze.database.card.get_card_by_property")
-def test_get_card_bad(mock_get: MagicMock):
+def test_get_card_bad(mock_get: MagicMock, asyncio_runner):
     mock_get.return_value = None
-    result = card_api.get_card_by("id", ObjectId(), card_class=Card)
+    result = card_api.get_card_by(runner=asyncio_runner, property_name="id", value=ObjectId(), card_class=Card)
     assert result is None
 
 
 @patch("scooze.database.card.get_cards_by_property")
-def test_get_base_cards(mock_get: MagicMock, cards_base: list[Card]):
+def test_get_base_cards(mock_get: MagicMock, cards_base, asyncio_runner):
     models = [CardModelOut.model_validate(card.__dict__) for card in cards_base]
     ids = [model.id for model in models]
     mock_get.return_value: list[CardModelOut] = models
-    results = card_api.get_cards_by("id", ids, card_class=Card)
+    results = card_api.get_cards_by(runner=asyncio_runner, property_name="id", values=ids, card_class=Card)
     assert results == cards_base
 
 
 @patch("scooze.database.card.get_cards_by_property")
-def test_get_oracle_cards(mock_get: MagicMock, cards_oracle: list[OracleCard]):
+def test_get_oracle_cards(mock_get: MagicMock, cards_oracle, asyncio_runner):
     models = [CardModelOut.model_validate(card.__dict__) for card in cards_oracle]
     ids = [model.id for model in models]
     mock_get.return_value: list[CardModelOut] = models
-    results = card_api.get_cards_by("id", ids, card_class=OracleCard)
+    results = card_api.get_cards_by(runner=asyncio_runner, property_name="id", values=ids, card_class=OracleCard)
     assert results == cards_oracle
 
 
 @patch("scooze.database.card.get_cards_by_property")
-def test_get_full_cards(mock_get: MagicMock, cards_full: list[FullCard]):
+def test_get_full_cards(mock_get: MagicMock, cards_full, asyncio_runner):
     models = [CardModelOut.model_validate(card.__dict__) for card in cards_full]
     ids = [model.id for model in models]
     mock_get.return_value: list[CardModelOut] = models
-    results = card_api.get_cards_by("id", ids, card_class=FullCard)
+    results = card_api.get_cards_by(runner=asyncio_runner, property_name="id", values=ids, card_class=FullCard)
     assert results == cards_full
 
 
 @patch("scooze.database.card.get_cards_by_property")
-def test_get_cards_bad(mock_get: MagicMock, cards_base: list[Card]):
+def test_get_cards_bad(mock_get: MagicMock, cards_base, asyncio_runner):
     mock_get.return_value = []
-    results = card_api.get_cards_by("id", [ObjectId() for _ in cards_base], card_class=Card)
+    results = card_api.get_cards_by(
+        runner=asyncio_runner, property_name="id", values=[ObjectId() for _ in cards_base], card_class=Card
+    )
     assert results == []
 
 
 @patch("scooze.database.card.add_card")
-def test_add_base_card(mock_add: MagicMock, recall_base: Card):
+def test_add_base_card(mock_add: MagicMock, recall_base, asyncio_runner):
     model = CardModelOut.model_validate(recall_base.__dict__)
     model.id = ObjectId()
     mock_add.return_value: CardModelOut = model
-    result = card_api.add_card(recall_base)
+    result = card_api.add_card(runner=asyncio_runner, card=recall_base)
     assert result == model.id
 
 
 @patch("scooze.database.card.add_card")
-def test_add_oracle_card(mock_add: MagicMock, recall_full: OracleCard):
+def test_add_oracle_card(mock_add: MagicMock, recall_full, asyncio_runner):
     model = CardModelOut.model_validate(recall_full.__dict__)
     model.id = ObjectId()
     mock_add.return_value: CardModelOut = model
-    result = card_api.add_card(recall_full)
+    result = card_api.add_card(runner=asyncio_runner, card=recall_full)
     assert result == model.id
 
 
 @patch("scooze.database.card.add_card")
-def test_add_full_card(mock_add: MagicMock, recall_full: FullCard):
+def test_add_full_card(mock_add: MagicMock, recall_full, asyncio_runner):
     model = CardModelOut.model_validate(recall_full.__dict__)
     model.id = ObjectId()
     mock_add.return_value: CardModelOut = model
-    result = card_api.add_card(recall_full)
+    result = card_api.add_card(runner=asyncio_runner, card=recall_full)
     assert result == model.id
 
 
 @patch("scooze.database.card.add_card")
-def test_add_card_bad(mock_add: MagicMock, recall_base: Card):
+def test_add_card_bad(mock_add: MagicMock, recall_base, asyncio_runner):
     mock_add.return_value = None
-    result = card_api.add_card(recall_base)
+    result = card_api.add_card(runner=asyncio_runner, card=recall_base)
     assert result is None
 
 
 @patch("scooze.database.card.add_cards")
-def test_add_base_cards(mock_add: MagicMock, cards_base: list[Card]):
+def test_add_base_cards(mock_add: MagicMock, cards_base, asyncio_runner):
     ids = [ObjectId() for _ in cards_base]
     mock_add.return_value: list[ObjectId] = ids
-    results = card_api.add_cards(cards_base)
+    results = card_api.add_cards(runner=asyncio_runner, cards=cards_base)
     assert results == ids
 
 
 @patch("scooze.database.card.add_cards")
-def test_add_oracle_cards(mock_add: MagicMock, cards_oracle: list[OracleCard]):
+def test_add_oracle_cards(mock_add: MagicMock, cards_oracle, asyncio_runner):
     ids = [ObjectId() for _ in cards_oracle]
     mock_add.return_value: list[ObjectId] = ids
-    results = card_api.add_cards(cards_oracle)
+    results = card_api.add_cards(runner=asyncio_runner, cards=cards_oracle)
     assert results == ids
 
 
 @patch("scooze.database.card.add_cards")
-def test_add_full_cards(mock_add: MagicMock, cards_full: list[FullCard]):
+def test_add_full_cards(mock_add: MagicMock, cards_full, asyncio_runner):
     ids = [ObjectId() for _ in cards_full]
     mock_add.return_value: list[ObjectId] = ids
-    results = card_api.add_cards(cards_full)
+    results = card_api.add_cards(runner=asyncio_runner, cards=cards_full)
     assert results == ids
 
 
 @patch("scooze.database.card.add_cards")
-def test_add_cards_bad(mock_add: MagicMock, cards_base: list[Card]):
+def test_add_cards_bad(mock_add: MagicMock, cards_base, asyncio_runner):
     mock_add.return_value = []
-    results = card_api.add_cards(cards_base)
+    results = card_api.add_cards(runner=asyncio_runner, cards=cards_base)
     assert results == []
 
 
 @patch("scooze.database.card.delete_cards_all")
-def test_delete_cards(mock_delete: MagicMock):
+def test_delete_cards(mock_delete: MagicMock, asyncio_runner):
     mock_delete.return_value: int = 4
-    results = card_api.delete_cards_all()
+    results = card_api.delete_cards_all(runner=asyncio_runner)
     assert results == 4
 
 
 @patch("scooze.database.card.delete_cards_all")
-def test_delete_cards_bad(mock_delete: MagicMock):
+def test_delete_cards_bad(mock_delete: MagicMock, asyncio_runner):
     mock_delete.return_value = None
-    results = card_api.delete_cards_all()
+    results = card_api.delete_cards_all(runner=asyncio_runner)
     assert results is None

--- a/tests/api/test_card_api.py
+++ b/tests/api/test_card_api.py
@@ -70,8 +70,9 @@ def test_get_full_cards(mock_get: MagicMock, cards_full, asyncio_runner):
 @patch("scooze.database.card.get_cards_by_property")
 def test_get_cards_bad(mock_get: MagicMock, cards_base, asyncio_runner):
     mock_get.return_value = []
-    results = asyncio_runner.run(card_api.get_cards_by(property_name="id", values=[ObjectId() for _ in cards_base], card_class=Card
-    ))
+    results = asyncio_runner.run(
+        card_api.get_cards_by(property_name="id", values=[ObjectId() for _ in cards_base], card_class=Card)
+    )
     assert results == []
 
 


### PR DESCRIPTION
First pass at a fix for the "Event Loop Closed" issue caused by calling

```
asyncio.run(coro)
```

too many times. Still need to test this a bit more, but here is an example of the current behavior still working:

![image](https://github.com/arcavios/scooze/assets/10965648/d170d73a-7d96-4f41-8653-e78651e1abd3)


Note to my future self - you can test this by merging this branch into the branch `deck_from_model` branch and running
```
pytest
```

Edit: I did this and it was a good way to test. If you load test cards to your local database and then grab the ObjectIds, you can see how it works when ScoozeApi.get_cards_by is using
```
self.runner.run(card_api.get_cards_by(...))
```
but if you change it to use 
```
asyncio.run(card_api.get_cards_by(...))
```
which is the behavior we were using before, you will encounter the "Event Loop Closed" error.