### PR TITLE
Refactor bulkdata API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Changed
 
 - Using Beanie for decks ([#272](https://github.com/arcavios/scooze/pull/272))
+- Refactored the bulkdata API endpoints ([#279](https://github.com/arcavios/scooze/pull/279))
 
 ### [1.0.7] - 2024-03-02
 

--- a/src/scooze/__init__.py
+++ b/src/scooze/__init__.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import logging.config
-from pathlib import Path
 import sys
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/src/scooze/__init__.py
+++ b/src/scooze/__init__.py
@@ -1,12 +1,12 @@
 import json
 import logging
 import logging.config
-import pathlib
+from pathlib import Path
 import sys
 
 logger = logging.getLogger(__name__)
 
-config_file = pathlib.Path("configs/logging_config.json")
+config_file = Path("configs/logging_config.json")
 with open(config_file) as f_in:
     logging_config = json.load(f_in)
 logging.config.dictConfig(config=logging_config)

--- a/src/scooze/api/__init__.py
+++ b/src/scooze/api/__init__.py
@@ -306,7 +306,6 @@ class ScoozeApi(AbstractContextManager):
     def load_card_file(self, file_type: ScryfallBulkFile, bulk_file_dir: str):
         """
         Loads the desired file from the given directory into a local database.
-        Attempts to download it from Scryfall if it isn't found.
 
         Args:
             file_type: The type of [ScryfallBulkFile](https://scryfall.com/docs/api/bulk-data)
@@ -607,7 +606,6 @@ class AsyncScoozeApi(AbstractAsyncContextManager):
     async def load_card_file(self, file_type: ScryfallBulkFile, bulk_file_dir: str):
         """
         Loads the desired file from the given directory into a local database.
-        Attempts to download it from Scryfall if it isn't found.
 
         Args:
             file_type: The type of [ScryfallBulkFile](https://scryfall.com/docs/api/bulk-data)

--- a/src/scooze/api/bulkdata.py
+++ b/src/scooze/api/bulkdata.py
@@ -6,54 +6,49 @@ from scooze.console import logger as cli_logger
 from scooze.models.card import CardModel, CardModelData
 
 
-async def load_card_file(file_type: ScryfallBulkFile, bulk_file_dir: str) -> None:
+async def load_card_file(file_type: ScryfallBulkFile, bulk_file_dir: str) -> int:
     """
     Loads the desired file from the given directory into a local Mongo
-    database. Attempts to download it from Scryfall if it isn't found.
+    database.
 
     Args:
         file_type: The type of [ScryfallBulkFile](https://scryfall.com/docs/api/bulk-data)
         to insert into the database.
         bulk_file_dir: The path to the folder containing the ScryfallBulkFile.
+
+    Returns:
+        The total number of cards loaded into the database.
     """
 
     file_path = f"{bulk_file_dir}/{file_type}.json"
-    try:
-        print(f"Loading {file_type} file into the database...")
-        with open(file_path, "rb") as cards_file:
-            batch_size = 5000
-            current_batch_count = 0
-            results_count = 0
-            current_batch: list[CardModel] = []
-            card_jsons = ijson.items(cards_file, "item")
+    batch_size = 5000
+    current_batch_count = 0
+    results_count = 0
+    current_batch: list[CardModel] = []
 
-            async def load_batch(batch: list[CardModel]) -> int:
-                batch_results = await CardModel.insert_many(batch)
-                if batch_results is not None:
-                    return len(batch_results.inserted_ids)
-                return 0
+    with open(file_path, "rb") as cards_file:
+        card_jsons = ijson.items(cards_file, "item")
 
-            for card_json in card_jsons:
-                if (validated_card := _try_validate_card(card_json)) is not None:
-                    current_batch.append(validated_card)
-                    current_batch_count += 1
-                    if current_batch_count >= batch_size:
-                        results_count += await load_batch(current_batch)
-                        current_batch = []
-                        current_batch_count = 0
-                        print(f"Finished processing {results_count} cards...", end="\r")
-            results_count += await load_batch(current_batch)
+        async def load_batch(batch: list[CardModel]) -> int:
+            batch_results = await CardModel.insert_many(batch)
+            if batch_results is not None:
+                return len(batch_results.inserted_ids)
+            return 0
 
-            print(f"Loaded {results_count} cards to the database.")
+        for card_json in card_jsons:
+            if (validated_card := _try_validate_card(card_json)) is not None:
+                current_batch.append(validated_card)
+                current_batch_count += 1
+                if current_batch_count >= batch_size:
+                    results_count += await load_batch(current_batch)
+                    current_batch = []
+                    current_batch_count = 0
+                    print(f"Finished processing {results_count} cards...", end="\r")
+        results_count += await load_batch(current_batch)
 
-    except FileNotFoundError:
-        print(file_path)
-        download_now = input(f"{file_type} file not found; would you like to download it now? [y/N] ") in "yY"
-        if not download_now:
-            print("No cards loaded into database.")
-            return
-        download_bulk_data_file_by_type(file_type, bulk_file_dir)
-        await load_card_file(file_type, bulk_file_dir)
+        print(f"Loaded {results_count} cards to the database.")
+
+    return results_count
 
 
 def _try_validate_card(card_json: dict) -> CardModel | None:

--- a/src/scooze/api/bulkdata.py
+++ b/src/scooze/api/bulkdata.py
@@ -22,7 +22,7 @@ async def load_card_file(file_type: ScryfallBulkFile, bulk_file_dir: str) -> int
 
     file_path = f"{bulk_file_dir}/{file_type}.json"
     batch_size = 5000
-    current_batch_count = 0
+    current_batch_count = 1
     results_count = 0
     current_batch: list[CardModel] = []
 

--- a/src/scooze/api/bulkdata.py
+++ b/src/scooze/api/bulkdata.py
@@ -22,7 +22,7 @@ async def load_card_file(file_type: ScryfallBulkFile, bulk_file_dir: str) -> int
 
     file_path = f"{bulk_file_dir}/{file_type}.json"
     batch_size = 5000
-    current_batch_count = 1
+    current_batch_count = 0
     results_count = 0
     current_batch: list[CardModel] = []
 

--- a/src/scooze/console/commands/load/cards.py
+++ b/src/scooze/console/commands/load/cards.py
@@ -1,4 +1,4 @@
-import pathlib
+from pathlib import Path
 from cleo.commands.command import Command
 from cleo.helpers import option
 from scooze.api import ScoozeApi
@@ -55,7 +55,7 @@ class LoadCardsCommand(Command):
                     download_bulk_data_file_by_type(bulk_file, self.option("bulk-data-dir"))
 
                 try:
-                    print(f"Reading from Scryfall data in: {pathlib.Path(self.option('bulk-data-dir'), bulk_file + '.json')}")
+                    print(f"Reading from Scryfall data in: {Path(self.option('bulk-data-dir'), bulk_file + '.json')}")
                     s.load_card_file(bulk_file, self.option("bulk-data-dir"))
                 except FileNotFoundError:
                     download_now = (

--- a/src/scooze/console/commands/load/cards.py
+++ b/src/scooze/console/commands/load/cards.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from cleo.commands.command import Command
 from cleo.helpers import option
 from scooze.api import ScoozeApi

--- a/src/scooze/console/commands/load/cards.py
+++ b/src/scooze/console/commands/load/cards.py
@@ -69,4 +69,5 @@ class LoadCardsCommand(Command):
                     s.load_card_file(bulk_file, self.option("bulk-data-dir"))
 
             if load_test:
+                print(f"Reading from Scryfall data in: {Path('data/test/default_cards.json')}")
                 s.load_card_file(ScryfallBulkFile.DEFAULT, "./data/test")

--- a/src/scooze/console/commands/load/cards.py
+++ b/src/scooze/console/commands/load/cards.py
@@ -51,7 +51,7 @@ class LoadCardsCommand(Command):
 
         with ScoozeApi() as s:
             for bulk_file in to_load:
-                if self.option("force-download") and not load_test:
+                if self.option("force-download"):
                     print(f"Downloading {bulk_file} from Scryfall...")
                     download_bulk_data_file_by_type(bulk_file, self.option("bulk-data-dir"))
 

--- a/src/scooze/console/commands/load/cards.py
+++ b/src/scooze/console/commands/load/cards.py
@@ -1,3 +1,4 @@
+import pathlib
 from cleo.commands.command import Command
 from cleo.helpers import option
 from scooze.api import ScoozeApi
@@ -49,14 +50,14 @@ class LoadCardsCommand(Command):
 
         with ScoozeApi() as s:
             for bulk_file in to_load:
-                if self.option("force-download"):
+                if self.option("force-download") and not load_test:
+                    print(f"Downloading {bulk_file} from Scryfall...")
                     download_bulk_data_file_by_type(bulk_file, self.option("bulk-data-dir"))
 
                 try:
-                    print(f"Loading {bulk_file} file into the database...")
+                    print(f"Reading from Scryfall data in: {pathlib.Path(self.option('bulk-data-dir'), bulk_file + '.json')}")
                     s.load_card_file(bulk_file, self.option("bulk-data-dir"))
                 except FileNotFoundError:
-                    print(f"Reading from Scryfall data in: {self.option('bulk-data-dir')}")
                     download_now = (
                         input(f"{bulk_file} file not found; would you like to download it now? [y/N] ") in "yY"
                     )

--- a/tests/api/test_bulkdata.py
+++ b/tests/api/test_bulkdata.py
@@ -25,48 +25,16 @@ class TestBulkDataWithEmptyDatabase:
     async def test_load_card_file(self, file_type: ScryfallBulkFile, bulk_file_dir: str, capfd):
         await bulk_api.load_card_file(file_type=file_type, bulk_file_dir=bulk_file_dir)
         captured = capfd.readouterr()
-        expected = f"Loading {file_type} file into the database...\nLoaded 9 cards to the database.\n"
+        expected = f"Loaded 9 cards to the database.\n"
         assert captured.out == expected
 
     @patch("scooze.api.bulkdata.open")
-    @patch("scooze.api.bulkdata.input")
     async def test_load_card_file_bad_no_download(
         self,
-        mock_input: MagicMock,
         mock_open: MagicMock,
         file_type: ScryfallBulkFile,
         bulk_file_dir: str,
-        capfd,
     ):
         mock_open.side_effect = FileNotFoundError
-        mock_input.return_value = "N"
-        await bulk_api.load_card_file(file_type=file_type, bulk_file_dir=bulk_file_dir)
-        captured = capfd.readouterr()
-        expected = f"Loading {file_type} file into the database...\n{bulk_file_dir}/{file_type}.json\nNo cards loaded into database.\n"
-        assert captured.out == expected
-
-    @patch("scooze.api.bulkdata.open")
-    @patch("scooze.api.bulkdata.input")
-    @patch("scooze.api.bulkdata.download_bulk_data_file_by_type")
-    async def test_load_card_file_bad_with_download(
-        self,
-        mock_download: MagicMock,
-        mock_input: MagicMock,
-        mock_open_custom: MagicMock,
-        file_type: ScryfallBulkFile,
-        bulk_file_dir: str,
-        capfd,
-    ):
-        # NOTE: Wrapping all of this test with the file open lets us use the actual
-        # file we're testing with as the second side effect for the 'open' mock
-        with open(f"{bulk_file_dir}/{file_type}.json", "rb") as test_file:
-            mock_open_custom.return_value.__enter__.side_effect = [FileNotFoundError, test_file]
-            mock_input.return_value = "Y"
-            mock_download.return_value = None
+        with pytest.raises(FileNotFoundError):
             await bulk_api.load_card_file(file_type=file_type, bulk_file_dir=bulk_file_dir)
-            captured = capfd.readouterr()
-            expected = (
-                f"Loading {file_type} file into the database...\n{bulk_file_dir}/{file_type}.json\n"
-                f"Loading {file_type} file into the database...\nLoaded 9 cards to the database.\n"
-            )
-            assert captured.out == expected

--- a/tests/api/test_bulkdata.py
+++ b/tests/api/test_bulkdata.py
@@ -29,7 +29,7 @@ class TestBulkDataWithEmptyDatabase:
         assert captured.out == expected
 
     @patch("scooze.api.bulkdata.open")
-    async def test_load_card_file_bad_no_download(
+    async def test_load_card_file_bad(
         self,
         mock_open: MagicMock,
         file_type: ScryfallBulkFile,


### PR DESCRIPTION
Moved the retry behavior and a lot of the print statements to the console command. This gives us better control over how the API endpoint is being called and allows for greater flexibility when using this endpoint in other places.

Added a flag to forcibly download the file and therefore allow users to skip the question of "do you want to download this now?"